### PR TITLE
update to live ruleset branches from validator specific branches

### DIFF
--- a/pvt-get-guidance-links/index.js
+++ b/pvt-get-guidance-links/index.js
@@ -20,7 +20,7 @@ module.exports = async (context, req) => {
             return;
         }
 
-        const rulesetBranch = `v${version}/validatorV2`;
+        const rulesetBranch = `version-${version}`;
 
         console.log({
             name: `Fetching ruleset for version: ${version}, repo: IATI-Rulesets, branch: ${rulesetBranch} `,


### PR DESCRIPTION
Updates the pvt-get-guidance links route to use the version-2.0X IATI-Ruleset branches rather than the v2.0X/validatorV2 branches﻿
