### PR TITLE
don't return errors object in ad-hoc validation session info endpoint

### DIFF
--- a/database/db.js
+++ b/database/db.js
@@ -199,7 +199,13 @@ module.exports = {
         SELECT 
             guid,
             filename, 
-            report, 
+            (SELECT case when report is null then null 
+                else jsonb_build_object(
+                    'valid',report->'valid',
+                    'summary',report->'summary',
+                    'fileType',report->'fileType',
+                    'iatiVersion',report->'iatiVersion'
+            ) end as report), 
             valid,
             session_id,
             created,

--- a/database/db.js
+++ b/database/db.js
@@ -100,7 +100,12 @@ module.exports = {
             doc.alv_error,
             val.created as validation_created, 
             val.valid,
-            val.report
+            (SELECT case when val.report is null then null else jsonb_build_object(
+                'valid',val.report->'valid',
+                'summary',val.report->'summary',
+                'fileType',val.report->'fileType',
+                'iatiVersion',val.report->'iatiVersion'
+            ) end as report)
         FROM document as doc
         LEFT JOIN validation AS val ON doc.validation = val.id
         WHERE doc.publisher = $1


### PR DESCRIPTION
[Trello 1](https://trello.com/c/LYSBkWlI)
[Trello 2](https://trello.com/c/iNxM2cTF)